### PR TITLE
feat: [#49] Git 연동 해제 및 예외처리 로직 변경

### DIFF
--- a/yaxim/src/main/java/com/yaxim/git/controller/GitController.java
+++ b/yaxim/src/main/java/com/yaxim/git/controller/GitController.java
@@ -1,11 +1,9 @@
 package com.yaxim.git.controller;
 
-import com.azure.core.annotation.Get;
 import com.yaxim.git.controller.dto.request.GitWebhookRequest;
 import com.yaxim.git.controller.dto.response.GitInfoResponse;
 import com.yaxim.git.service.GitInfoService;
 import com.yaxim.global.auth.jwt.JwtAuthentication;
-import com.yaxim.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RequestMapping("/git")
 @RequiredArgsConstructor
-public class GitWebhookController {
+public class GitController {
     private final GitInfoService gitInfoService;
 
     @PostMapping("/webhook")
@@ -28,5 +26,10 @@ public class GitWebhookController {
         return ResponseEntity.ok(
                 gitInfoService.getGitInfo(auth.getUserId())
         );
+    }
+
+    @DeleteMapping
+    public void deleteGitInfo(JwtAuthentication auth) {
+        gitInfoService.deleteGitInfo(auth.getUserId());
     }
 }

--- a/yaxim/src/main/java/com/yaxim/git/controller/dto/response/GitInfoResponse.java
+++ b/yaxim/src/main/java/com/yaxim/git/controller/dto/response/GitInfoResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class GitInfoResponse {
+    private boolean connected;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private String gitId;

--- a/yaxim/src/main/java/com/yaxim/git/service/GitInfoService.java
+++ b/yaxim/src/main/java/com/yaxim/git/service/GitInfoService.java
@@ -84,4 +84,14 @@ public class GitInfoService {
 
         team.setInstallationId(request.getInstallation().getId());
     }
+
+    @Transactional
+    public void deleteGitInfo(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        GitInfo info = gitInfoRepository.findByUser(user)
+                .orElseThrow(GitInfoNotFoundException::new);
+
+        gitInfoRepository.delete(info);
+    }
 }

--- a/yaxim/src/main/java/com/yaxim/git/service/GitInfoService.java
+++ b/yaxim/src/main/java/com/yaxim/git/service/GitInfoService.java
@@ -45,8 +45,19 @@ public class GitInfoService {
                 .orElseThrow(UserNotFoundException::new);
 
         GitInfo info = gitInfoRepository.findByUser(user)
-                .orElseThrow(GitInfoNotFoundException::new);
+                .orElse(new GitInfo(user));
+//                .orElseThrow(GitInfoNotFoundException::new);
+
+        if (info.getGitId() == null) {
+            return getGitResponse(false, info);
+        } else {
+            return getGitResponse(true, info);
+        }
+    }
+
+    private GitInfoResponse getGitResponse(boolean isConnected, GitInfo info) {
         return new GitInfoResponse(
+                isConnected,
                 info.getCreatedAt(),
                 info.getUpdatedAt(),
                 info.getGitId(),


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] Git 연동 정보가 없을 때 기존에 404를 리턴하던 로직에서, Reponse DTO에 'connected' 변수를 추가하여 연동 여부를 알 수 있도록 200번을 리턴하도록 하였습니다. 연동 정보가 없을 경우 connected 변수를 제외한 모든 변수가 null로 제공됩니다.
- [x] Git 연동을 해제하는 역할을 하도록 GitInfo Table을 삭제하는 API를 추가하였습니다.