### PR TITLE
refactor: [#50] Teams에서 유저 이름이 저장되는 방식 수정 및 확장성을 위한 CasacadeType 설정

### DIFF
--- a/yaxim/src/main/java/com/yaxim/git/entity/GitInfo.java
+++ b/yaxim/src/main/java/com/yaxim/git/entity/GitInfo.java
@@ -17,7 +17,7 @@ public class GitInfo extends BaseEntity {
     private Long id;
 
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id")
     private Users user;
 

--- a/yaxim/src/main/java/com/yaxim/git/service/GitInfoService.java
+++ b/yaxim/src/main/java/com/yaxim/git/service/GitInfoService.java
@@ -29,8 +29,11 @@ public class GitInfoService {
 
     @Transactional
     public void updateGitInfo(Users user, GitInfo gitInfo) {
-        GitInfo info = gitInfoRepository.findByUser(user)
-                        .orElse(new GitInfo(user));
+        Users managedUser = userRepository.findById(user.getId())
+                .orElseThrow(UserNotFoundException::new);
+
+        GitInfo info = gitInfoRepository.findByUser(managedUser)
+                        .orElse(new GitInfo(managedUser));
         info.setGitId(gitInfo.getGitId());
         info.setGitEmail(gitInfo.getGitEmail());
         info.setGitUrl(gitInfo.getGitUrl());

--- a/yaxim/src/main/java/com/yaxim/global/auth/oauth2/OAuth2UserInfo.java
+++ b/yaxim/src/main/java/com/yaxim/global/auth/oauth2/OAuth2UserInfo.java
@@ -42,7 +42,7 @@ public class OAuth2UserInfo {
         }
 
         return OAuth2UserInfo.builder()
-                .name((String) attributes.get("name"))
+                .name(attributes.get("family_name") + (String) attributes.get("given_name"))
                 .email(email)
                 .build();
     }


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] 유저 이름이 기존에는 '성 이름' 형식으로 저장되었는데, '성이름' 형식으로 저장되도록 수정하였습니다.
- [x] 유저 탈퇴 시나리오가 생길 경우를 대비하여 CasacadeType을 설정하였습니다.
