### PR TITLE
feat: [#74] 업무 통계 기능 구현

### DIFF
--- a/yaxim/src/main/java/com/yaxim/statics/controller/StaticsController.java
+++ b/yaxim/src/main/java/com/yaxim/statics/controller/StaticsController.java
@@ -1,0 +1,47 @@
+package com.yaxim.statics.controller;
+
+import com.yaxim.global.auth.aop.CheckRole;
+import com.yaxim.global.auth.jwt.JwtAuthentication;
+import com.yaxim.statics.controller.dto.response.AverageStaticsResponse;
+import com.yaxim.statics.controller.dto.response.GeneralStaticsResponse;
+import com.yaxim.statics.service.TeamStaticsService;
+import com.yaxim.statics.service.UserStaticsService;
+import com.yaxim.user.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/statics")
+@RequiredArgsConstructor
+public class StaticsController {
+    private final UserStaticsService userStaticsService;
+    private final TeamStaticsService teamStaticsService;
+
+    @GetMapping("/user")
+    public ResponseEntity<List<GeneralStaticsResponse>> getUserStatics(JwtAuthentication auth) {
+        return ResponseEntity.ok(userStaticsService.getUserStatic(auth.getUserId()));
+    }
+
+    @GetMapping("/user/avg")
+    public ResponseEntity<List<AverageStaticsResponse>> getUserStatics() {
+        return ResponseEntity.ok(userStaticsService.getUsersAverageStatic());
+    }
+
+    @CheckRole(UserRole.LEADER)
+    @GetMapping("/team")
+    public ResponseEntity<List<GeneralStaticsResponse>> getTeamStatics(JwtAuthentication auth) {
+        return ResponseEntity.ok(teamStaticsService.getTeamStatic(auth.getUserId()));
+    }
+
+    @CheckRole(UserRole.LEADER)
+    @GetMapping("/team/avg")
+    public ResponseEntity<List<AverageStaticsResponse>> getTeamStatics() {
+        return ResponseEntity.ok(teamStaticsService.getTeamsAverageStatic());
+    }
+
+}

--- a/yaxim/src/main/java/com/yaxim/statics/controller/dto/response/AverageStaticsResponse.java
+++ b/yaxim/src/main/java/com/yaxim/statics/controller/dto/response/AverageStaticsResponse.java
@@ -1,0 +1,71 @@
+package com.yaxim.statics.controller.dto.response;
+
+import com.yaxim.statics.entity.select.AverageActivity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AverageStaticsResponse {
+    private LocalDate report_date;
+    private Teams teams;
+    private Docs docs;
+    private Email email;
+    private Git git;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Docs {
+        private Double docx;
+        private Double xlsx;
+        private Double txt;
+        private Double etc;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Email {
+        private Double receive;
+        private Double send;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Git {
+        private Double pull_request;
+        private Double commit;
+        private Double issue;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Teams {
+        private Double post;
+    }
+
+    public static AverageStaticsResponse from(AverageActivity activity) {
+        return new AverageStaticsResponse(
+                activity.getReportDate(),
+                new AverageStaticsResponse.Teams(activity.getTeamsPost()),
+                new AverageStaticsResponse.Docs(
+                        activity.getDocsDocx(),
+                        activity.getDocsXlsx(),
+                        (double) 0,
+                        activity.getDocsEtc()
+                ),
+                new AverageStaticsResponse.Email(
+                        activity.getEmailReceive(),
+                        activity.getEmailSend()
+                ),
+                new AverageStaticsResponse.Git(
+                        activity.getGitPullRequest(),
+                        activity.getGitCommit(),
+                        activity.getGitIssue()
+                )
+        );
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/statics/controller/dto/response/GeneralStaticsResponse.java
+++ b/yaxim/src/main/java/com/yaxim/statics/controller/dto/response/GeneralStaticsResponse.java
@@ -1,0 +1,97 @@
+package com.yaxim.statics.controller.dto.response;
+
+import com.yaxim.statics.entity.DailyUserActivity;
+import com.yaxim.statics.entity.DailyTeamActivity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GeneralStaticsResponse {
+    private LocalDate report_date;
+    private Teams teams;
+    private Docs docs;
+    private Email email;
+    private Git git;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Teams {
+        private Long post;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Docs {
+        private Long docx;
+        private Long xlsx;
+        private Long txt;
+        private Long etc;
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Email {
+        private Long receive;
+        private Long send;
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Git {
+        private Long pull_request;
+        private Long commit;
+        private Long issue;
+
+    }
+
+    public static GeneralStaticsResponse from(DailyUserActivity activity) {
+        return new GeneralStaticsResponse(
+                activity.getReportDate(),
+                new GeneralStaticsResponse.Teams(activity.getTeamsPost()),
+                new GeneralStaticsResponse.Docs(
+                        activity.getDocsDocx(),
+                        activity.getDocsXlsx(),
+                        (long) 0,
+                        activity.getDocsEtc()
+                ),
+                new GeneralStaticsResponse.Email(
+                        activity.getEmailReceive(),
+                        activity.getEmailSend()
+                ),
+                new GeneralStaticsResponse.Git(
+                        activity.getGitPullRequest(),
+                        activity.getGitCommit(),
+                        activity.getGitIssue()
+                )
+        );
+    }
+
+    public static GeneralStaticsResponse from(DailyTeamActivity activity) {
+        return new GeneralStaticsResponse(
+                activity.getReportDate(),
+                new GeneralStaticsResponse.Teams(activity.getTeamsPost()),
+                new GeneralStaticsResponse.Docs(
+                        activity.getDocsDocx(),
+                        activity.getDocsXlsx(),
+                        (long) 0,
+                        activity.getDocsEtc()
+                ),
+                new GeneralStaticsResponse.Email(
+                        activity.getEmailReceive(),
+                        activity.getEmailSend()
+                ),
+                new GeneralStaticsResponse.Git(
+                        activity.getGitPullRequest(),
+                        activity.getGitCommit(),
+                        activity.getGitIssue()
+                )
+        );
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/statics/entity/DailyTeamActivity.java
+++ b/yaxim/src/main/java/com/yaxim/statics/entity/DailyTeamActivity.java
@@ -1,0 +1,69 @@
+package com.yaxim.statics.entity;
+
+import com.yaxim.team.entity.Team;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class DailyTeamActivity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate reportDate;
+    private Long teamsPost;
+    private Long emailSend;
+    private Long emailReceive;
+    private Long docsDocx;
+    private Long docsXlsx;
+    private Long docsTxt;
+    private Long docsEtc;
+    private Long gitPullRequest;
+    private Long gitCommit;
+    private Long gitIssue;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Weekday day;
+
+    public DailyTeamActivity(
+            LocalDate reportDate,
+            Long teamsPost,
+            Long emailSend,
+            Long emailReceive,
+            Long docsDocx,
+            Long docsXlsx,
+            Long docsTxt,
+            Long docsEtc,
+            Long gitPullRequest,
+            Long gitCommit,
+            Long gitIssue,
+            Team team,
+            Weekday day
+    ) {
+        this.reportDate = reportDate;
+        this.teamsPost = teamsPost;
+        this.emailSend = emailSend;
+        this.emailReceive = emailReceive;
+        this.docsDocx = docsDocx;
+        this.docsXlsx = docsXlsx;
+        this.docsTxt = docsTxt;
+        this.docsEtc = docsEtc;
+        this.gitPullRequest = gitPullRequest;
+        this.gitCommit = gitCommit;
+        this.gitIssue = gitIssue;
+        this.team = team;
+        this.day = day;
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/statics/entity/DailyUserActivity.java
+++ b/yaxim/src/main/java/com/yaxim/statics/entity/DailyUserActivity.java
@@ -1,0 +1,42 @@
+package com.yaxim.statics.entity;
+
+import com.yaxim.user.entity.Users;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class DailyUserActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Weekday day;
+
+    private LocalDate reportDate;
+    private Long teamsPost;
+    private Long emailSend;
+    private Long emailReceive;
+    private Long docsDocx;
+    private Long docsXlsx;
+    private Long docsTxt;
+    private Long docsEtc;
+    private Long gitPullRequest;
+    private Long gitCommit;
+    private Long gitIssue;
+}
+

--- a/yaxim/src/main/java/com/yaxim/statics/entity/Weekday.java
+++ b/yaxim/src/main/java/com/yaxim/statics/entity/Weekday.java
@@ -1,0 +1,29 @@
+package com.yaxim.statics.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Weekday {
+    FRIDAY(0),
+    SATURDAY(1),
+    SUNDAY(2),
+    MONDAY(3),
+    TUESDAY(4),
+    WEDNESDAY(5),
+    THURSDAY(6);
+
+    private final int code;
+
+    Weekday(int code) {
+        this.code = code;
+    }
+
+    public static Weekday of(int code) {
+        for (Weekday w : Weekday.values()) {
+            if (w.code == code) {
+                return w;
+            }
+        }
+        throw new IllegalArgumentException("Invalid weekday code: " + code);
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/statics/entity/select/AverageActivity.java
+++ b/yaxim/src/main/java/com/yaxim/statics/entity/select/AverageActivity.java
@@ -1,0 +1,22 @@
+package com.yaxim.statics.entity.select;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class AverageActivity {
+    private LocalDate reportDate;
+    private Double teamsPost;
+    private Double docsDocx;
+    private Double docsXlsx;
+    private Double docsTxt;
+    private Double docsEtc;
+    private Double emailReceive;
+    private Double emailSend;
+    private Double gitPullRequest;
+    private Double gitCommit;
+    private Double gitIssue;
+}

--- a/yaxim/src/main/java/com/yaxim/statics/entity/select/TeamActivity.java
+++ b/yaxim/src/main/java/com/yaxim/statics/entity/select/TeamActivity.java
@@ -1,0 +1,22 @@
+package com.yaxim.statics.entity.select;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class TeamActivity {
+    private LocalDate reportDate;
+    private Long teamsPost;
+    private Long docsDocx;
+    private Long docsXlsx;
+    private Long docsTxt;
+    private Long docsEtc;
+    private Long emailReceive;
+    private Long emailSend;
+    private Long gitPullRequest;
+    private Long gitCommit;
+    private Long gitIssue;
+}

--- a/yaxim/src/main/java/com/yaxim/statics/repository/TeamStaticsRepository.java
+++ b/yaxim/src/main/java/com/yaxim/statics/repository/TeamStaticsRepository.java
@@ -1,0 +1,35 @@
+package com.yaxim.statics.repository;
+
+import com.yaxim.statics.entity.Weekday;
+import com.yaxim.statics.entity.DailyTeamActivity;
+import com.yaxim.statics.entity.select.AverageActivity;
+import com.yaxim.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface TeamStaticsRepository extends JpaRepository<DailyTeamActivity, Long> {
+    Boolean existsAllByTeamId(String team_id);
+    List<DailyTeamActivity> findAllByTeam(Team team);
+
+    @Query("""
+    SELECT new com.yaxim.statics.entity.select.AverageActivity(
+        a.reportDate,
+            AVG(a.teamsPost),
+            AVG(a.docsDocx),
+            AVG(a.docsXlsx),
+            AVG(a.docsTxt),
+            AVG(a.docsEtc),
+            AVG(a.emailReceive),
+            AVG(a.emailSend),
+            AVG(a.gitPullRequest),
+            AVG(a.gitCommit),
+            AVG(a.gitIssue)
+    )
+    FROM DailyTeamActivity a
+    WHERE a.team = :team and a.day = :day
+    GROUP BY a.reportDate
+    """)
+    AverageActivity getTeamAvgByDayAndTeam(Weekday day, Team team);
+}

--- a/yaxim/src/main/java/com/yaxim/statics/repository/UserStaticsRepository.java
+++ b/yaxim/src/main/java/com/yaxim/statics/repository/UserStaticsRepository.java
@@ -1,0 +1,56 @@
+package com.yaxim.statics.repository;
+
+import com.yaxim.statics.entity.select.AverageActivity;
+import com.yaxim.statics.entity.DailyUserActivity;
+import com.yaxim.statics.entity.Weekday;
+import com.yaxim.statics.entity.select.TeamActivity;
+import com.yaxim.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface UserStaticsRepository extends JpaRepository<DailyUserActivity, Long> {
+    List<DailyUserActivity> findAllByUserId(Long userId);
+
+    @Query("""
+        SELECT new com.yaxim.statics.entity.select.AverageActivity (
+            a.reportDate,
+            AVG(a.teamsPost),
+            AVG(a.docsDocx),
+            AVG(a.docsXlsx),
+            AVG(a.docsTxt),
+            AVG(a.docsEtc),
+            AVG(a.emailReceive),
+            AVG(a.emailSend),
+            AVG(a.gitPullRequest),
+            AVG(a.gitCommit),
+            AVG(a.gitIssue)
+        )
+        FROM DailyUserActivity a
+        WHERE a.day = :day
+        GROUP BY a.reportDate
+    """)
+    AverageActivity getUserAvgActivityByWeekDay(Weekday day);
+
+    @Query("""
+        SELECT new com.yaxim.statics.entity.select.TeamActivity (
+            a.reportDate,
+            SUM(a.teamsPost),
+            SUM(a.docsDocx),
+            SUM(a.docsXlsx),
+            SUM(a.docsTxt),
+            SUM(a.docsEtc),
+            SUM(a.emailReceive),
+            SUM(a.emailSend),
+            SUM(a.gitPullRequest),
+            SUM(a.gitCommit),
+            SUM(a.gitIssue)
+        )
+        FROM DailyUserActivity a
+        WHERE a.user in :users AND a.day = :day
+        GROUP BY a.reportDate
+    """)
+    TeamActivity getTeamActivityByWeekdayAndUser(Weekday day, List<Users> users);
+
+}

--- a/yaxim/src/main/java/com/yaxim/statics/service/TeamStaticsService.java
+++ b/yaxim/src/main/java/com/yaxim/statics/service/TeamStaticsService.java
@@ -1,0 +1,103 @@
+package com.yaxim.statics.service;
+
+import com.yaxim.statics.controller.dto.response.AverageStaticsResponse;
+import com.yaxim.statics.controller.dto.response.GeneralStaticsResponse;
+import com.yaxim.statics.entity.Weekday;
+import com.yaxim.statics.entity.DailyTeamActivity;
+import com.yaxim.statics.entity.select.AverageActivity;
+import com.yaxim.statics.entity.select.TeamActivity;
+import com.yaxim.statics.repository.TeamStaticsRepository;
+import com.yaxim.statics.repository.UserStaticsRepository;
+import com.yaxim.team.entity.Team;
+import com.yaxim.team.exception.TeamMemberNotMappedException;
+import com.yaxim.team.repository.TeamMemberRepository;
+import com.yaxim.team.repository.TeamRepository;
+import com.yaxim.user.entity.Users;
+import com.yaxim.user.exception.UserNotFoundException;
+import com.yaxim.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TeamStaticsService {
+    private final UserRepository userRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final UserStaticsRepository userStaticsRepository;
+    private final TeamStaticsRepository teamStaticsRepository;
+    private final TeamRepository teamRepository;
+
+    public List<GeneralStaticsResponse> getTeamStatic(Long userId) {
+        Team team = getTeamByUserId(userId);
+
+        Boolean hasData = teamStaticsRepository.existsAllByTeamId(team.getId());
+
+        List<DailyTeamActivity> activities = new ArrayList<>();
+
+        if (hasData) {
+            activities = teamStaticsRepository.findAllByTeam(team);
+        } else {
+            List<Users> users = userRepository.findAllByEmailIn(
+                    teamMemberRepository.getEmailsByTeamIn(team)
+            );
+
+            for (int i = 0; i < 7; i++) {
+                TeamActivity data = userStaticsRepository.getTeamActivityByWeekdayAndUser(Weekday.of(i), users);
+
+                DailyTeamActivity activity = teamStaticsRepository.save(
+                        new DailyTeamActivity(
+                                data.getReportDate(),
+                                data.getTeamsPost(),
+                                data.getEmailSend(),
+                                data.getEmailReceive(),
+                                data.getDocsDocx(),
+                                data.getDocsXlsx(),
+                                data.getDocsTxt(),
+                                data.getDocsEtc(),
+                                data.getGitPullRequest(),
+                                data.getGitCommit(),
+                                data.getGitIssue(),
+                                team,
+                                Weekday.of(i)
+                        )
+                );
+
+                activities.add(activity);
+            }
+        }
+
+        return activities.stream()
+                .map(GeneralStaticsResponse::from)
+                .toList();
+    }
+
+    public List<AverageStaticsResponse> getTeamsAverageStatic() {
+        List<Team> teams = teamRepository.findAll();
+
+        List<AverageActivity> activities = new ArrayList<>();
+
+        for (Team team : teams) {
+            for (int i = 0; i < 7; i++) {
+                activities.add(teamStaticsRepository.getTeamAvgByDayAndTeam(Weekday.of(i), team));
+            }
+        }
+
+        return activities.stream()
+                .map(AverageStaticsResponse::from)
+                .toList();
+    }
+
+    private Team getTeamByUserId(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        return teamMemberRepository.findByEmail(user.getEmail())
+                .orElseThrow(TeamMemberNotMappedException::new)
+                .getTeam();
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/statics/service/UserStaticsService.java
+++ b/yaxim/src/main/java/com/yaxim/statics/service/UserStaticsService.java
@@ -1,0 +1,41 @@
+package com.yaxim.statics.service;
+
+import com.yaxim.statics.entity.select.AverageActivity;
+import com.yaxim.statics.controller.dto.response.AverageStaticsResponse;
+import com.yaxim.statics.controller.dto.response.GeneralStaticsResponse;
+import com.yaxim.statics.entity.DailyUserActivity;
+import com.yaxim.statics.entity.Weekday;
+import com.yaxim.statics.repository.UserStaticsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserStaticsService {
+    private final UserStaticsRepository userStaticsRepository;
+
+    public List<GeneralStaticsResponse> getUserStatic(Long userId) {
+        List<DailyUserActivity> activities = userStaticsRepository.findAllByUserId(userId);
+
+        return activities.stream()
+                .map(GeneralStaticsResponse::from)
+                .toList();
+    }
+
+    public List<AverageStaticsResponse> getUsersAverageStatic() {
+        List<AverageActivity> activities = new ArrayList<>();
+
+        for (int i = 0; i < 7; i++) {
+            activities.add(userStaticsRepository.getUserAvgActivityByWeekDay(Weekday.of(i)));
+        }
+
+        return activities.stream()
+                .map(AverageStaticsResponse::from)
+                .toList();
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/team/repository/TeamMemberRepository.java
+++ b/yaxim/src/main/java/com/yaxim/team/repository/TeamMemberRepository.java
@@ -3,6 +3,7 @@ package com.yaxim.team.repository;
 import com.yaxim.team.entity.Team;
 import com.yaxim.team.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,5 +12,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findByEmail(String email);
     List<TeamMember> findByTeam(Team team);
     List<TeamMember> findByTeamId(String teamId);
-//    Optional<TeamMember> findByTeamIdAndEmail(String teamId, String email);
+
+    @Query("SELECT u.email FROM TeamMember u WHERE u.team = :team")
+    List<String> getEmailsByTeamIn(Team team);
 }

--- a/yaxim/src/main/java/com/yaxim/user/repository/UserRepository.java
+++ b/yaxim/src/main/java/com/yaxim/user/repository/UserRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByEmail(String email);
     boolean existsByEmail(String email);
+    List<Users> findAllByEmailIn(List<String> emails);
 }


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] DB에 적재되어있는 일별 사용자의 업무량을 기반으로 일별 사용자의 업무량, 일별 전체 사용자의 평균 업무량, 일별 팀 단위 업무량, 일별 팀 단위 평균 업무량 통계 정보를 조회하는 기능을 구현하였습니다.

## 💬 리뷰 요구사항 or 추가 코멘트
> 최대한 빠른 시일 내에 일주일별 업무량 통계도 포함하겠습니다,,
