### PR TITLE
feat: [#86] AI 전용 프로젝트 정보 반환 기능

### DIFF
--- a/yaxim/src/main/java/com/yaxim/global/for_ai/ApiForAiController.java
+++ b/yaxim/src/main/java/com/yaxim/global/for_ai/ApiForAiController.java
@@ -3,6 +3,7 @@ package com.yaxim.global.for_ai;
 import com.yaxim.global.for_ai.dto.request.DailyReportCreateRequest;
 import com.yaxim.global.for_ai.dto.request.TeamWeeklyReportCreateRequest;
 import com.yaxim.global.for_ai.dto.request.WeeklyReportCreateRequest;
+import com.yaxim.global.for_ai.dto.response.TeamWithProjectResponse;
 import com.yaxim.report.controller.dto.response.DailyReportDetailResponse;
 import com.yaxim.report.controller.dto.response.WeeklyReportDetailResponse;
 import com.yaxim.report.service.TeamWeeklyReportService;
@@ -45,11 +46,11 @@ public class ApiForAiController {
         return ResponseEntity.ok(teamService.getTeamWithMemberResponses());
     }
 
-//    @GetMapping("/team/project")
-//    @Operation(summary = "DB에 저장되어 있는 팀별 프로젝트 정보 조회")
-//    public ResponseEntity<List<TeamWithMemberResponse>> getTeamWithMemberResponsesForProject() {
-//
-//    }
+    @GetMapping("/team/project")
+    @Operation(summary = "DB에 저장되어 있는 팀별 프로젝트 정보 조회")
+    public ResponseEntity<List<TeamWithProjectResponse>> getTeamWithProjectResponses() {
+        return ResponseEntity.ok(teamService.getTeamWithProjectResponses());
+    }
 
     // Report
 
@@ -76,8 +77,6 @@ public class ApiForAiController {
         WeeklyReportDetailResponse response = teamWeeklyReportService.createTeamWeeklyReport(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
-    // TODO Project (team id로 프로젝트 조회)
 
     // TODO LLM One Line Comment (DailyUserReport 테이블에 Comment 컬럼 추가)
 }

--- a/yaxim/src/main/java/com/yaxim/global/for_ai/dto/response/TeamWithMemberResponse.java
+++ b/yaxim/src/main/java/com/yaxim/global/for_ai/dto/response/TeamWithMemberResponse.java
@@ -11,8 +11,6 @@ import java.util.List;
 @AllArgsConstructor
 public class TeamWithMemberResponse {
     private String id;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
     private String name;
     private String description;
     private List<TeamMemberResponse> members;

--- a/yaxim/src/main/java/com/yaxim/global/for_ai/dto/response/TeamWithProjectResponse.java
+++ b/yaxim/src/main/java/com/yaxim/global/for_ai/dto/response/TeamWithProjectResponse.java
@@ -1,0 +1,16 @@
+package com.yaxim.global.for_ai.dto.response;
+
+import com.yaxim.project.controller.dto.response.ProjectDetailResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TeamWithProjectResponse {
+    private String id;
+    private String name;
+    private String description;
+    private List<ProjectDetailResponse> projects;
+}

--- a/yaxim/src/main/java/com/yaxim/project/repository/ProjectRepository.java
+++ b/yaxim/src/main/java/com/yaxim/project/repository/ProjectRepository.java
@@ -7,11 +7,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     // 팀별 프로젝트 목록 조회 (페이징)
     Page<Project> findByTeam(Team team, Pageable pageable);
+
+    List<Project> findByTeam(Team team);
 
 //    // 프로젝트명으로 검색 (페이징) - 필드명 수정: projectName → name
 //    Page<Project> findByTeamIdAndNameContainingIgnoreCase(String teamId, String name, Pageable pageable);

--- a/yaxim/src/main/java/com/yaxim/team/service/TeamService.java
+++ b/yaxim/src/main/java/com/yaxim/team/service/TeamService.java
@@ -1,9 +1,13 @@
 package com.yaxim.team.service;
 
 import com.yaxim.global.auth.jwt.TokenService;
+import com.yaxim.global.for_ai.dto.response.TeamWithProjectResponse;
 import com.yaxim.graph.GraphApiService;
 import com.yaxim.graph.controller.dto.GraphTeamMemberResponse;
 import com.yaxim.graph.controller.dto.GraphTeamResponse;
+import com.yaxim.project.controller.dto.response.ProjectDetailResponse;
+import com.yaxim.project.entity.Project;
+import com.yaxim.project.repository.ProjectRepository;
 import com.yaxim.team.controller.dto.response.TeamMemberResponse;
 import com.yaxim.team.controller.dto.response.TeamResponse;
 import com.yaxim.global.for_ai.dto.response.TeamWithMemberResponse;
@@ -34,6 +38,7 @@ public class TeamService {
     private final GraphApiService graphApiService;
     private final UserRepository userRepository;
     private final TokenService tokenService;
+    private final ProjectRepository projectRepository;
 
     public TeamResponse getUserTeam(Long userId) {
         Users user = userRepository.findById(userId)
@@ -143,8 +148,6 @@ public class TeamService {
                 List<TeamMemberResponse> memberResponses = getTeamMemberResponse(members);
                 return new TeamWithMemberResponse(
                         team.getId(),
-                        team.getCreatedAt(),
-                        team.getUpdatedAt(),
                         team.getName(),
                         team.getDescription(),
                         memberResponses
@@ -153,4 +156,19 @@ public class TeamService {
             .toList();
         }
 
+    public List<TeamWithProjectResponse> getTeamWithProjectResponses() {
+        List<Team> teams = teamRepository.findAll();
+
+        return teams.stream()
+                .map(team -> {
+                    List<Project> projects = projectRepository.findByTeam(team);
+
+                    return new TeamWithProjectResponse(
+                            team.getId(),
+                            team.getName(),
+                            team.getDescription(),
+                            projects.stream().map(ProjectDetailResponse::from).toList()
+                    );
+                }).toList();
+    }
 }


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] 팀 정보와 프로젝트 정보를 함께 반환하는 기능을 추가하였습니다. AI 코드를 보았을 때, 프로젝트 정보와 팀 멤버 정보가 한꺼번에 필요한 곳이 없는 것 같아 분리하여 API를 만들었습니다.
- [x] 일부 불필요해보였던 Response 값들도 정리하였습니다.


## 💬 리뷰 요구사항 or 추가 코멘트
> AI 서버에서 api.yaxim 으로 바로 API를 날릴 수 있도록, 배포된 서버에 프로젝트 정보 및 업무 통계 정보, 테스트용 계정의 데일리, 위클리, 팀 위클리 데이터를 마이그레이션(?) 해 두었으니, 로컬에서 테스트 하지 마시고 배포된 서버 URL로 테스트하세용
 
