### PR TITLE
feat: [#97] 유저 아이디 목록, 시작 날짜, 종료 날짜 필터 기능 추가

### DIFF
--- a/yaxim/build.gradle
+++ b/yaxim/build.gradle
@@ -69,6 +69,12 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // queryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // ✅ DevTools - 개발 시 hot reload 지원
     //developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/yaxim/src/main/java/com/yaxim/global/config/QueryDslConfig.java
+++ b/yaxim/src/main/java/com/yaxim/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.yaxim.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/global/for_ai/ApiForAiController.java
+++ b/yaxim/src/main/java/com/yaxim/global/for_ai/ApiForAiController.java
@@ -38,18 +38,6 @@ public class ApiForAiController {
         return ResponseEntity.ok(teamService.getAllTeamsInfo());
     }
 
-//    @GetMapping("/team/all/members")
-//    @Operation(summary = "DB에 저장되어 있는 모든 팀 및 팀 멤버 정보 조회")
-//    public ResponseEntity<List<TeamWithMemberAndProjectResponse>> getTeamWithMemberResponses() {
-//        return ResponseEntity.ok(teamService.getTeamWithMemberResponses());
-//    }
-//
-//    @GetMapping("/team/project")
-//    @Operation(summary = "DB에 저장되어 있는 팀별 프로젝트 정보 조회")
-//    public ResponseEntity<List<TeamWithProjectResponse>> getTeamWithProjectResponses() {
-//        return ResponseEntity.ok(teamService.getTeamWithProjectResponses());
-//    }
-
     // Report
 
     @Operation(summary = "개인 Daily 생성")

--- a/yaxim/src/main/java/com/yaxim/report/controller/TeamWeeklyReportController.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/TeamWeeklyReportController.java
@@ -2,6 +2,7 @@ package com.yaxim.report.controller;
 
 import com.yaxim.global.auth.aop.CheckRole;
 import com.yaxim.global.auth.jwt.JwtAuthentication;
+import com.yaxim.report.controller.dto.request.TeamMemberWeeklyPageRequest;
 import com.yaxim.report.controller.dto.response.TeamMemberWeeklyDetailResponse;
 import com.yaxim.report.controller.dto.response.TeamMemberWeeklyReportResponse;
 import com.yaxim.report.controller.dto.response.WeeklyReportDetailResponse;
@@ -31,11 +32,13 @@ public class TeamWeeklyReportController {
     @Operation(summary = "팀 멤버 보고서 목록 조회")
     @GetMapping("/member")
     public ResponseEntity<Page<TeamMemberWeeklyReportResponse>> getTeamMemberWeeklyReports(
+            TeamMemberWeeklyPageRequest request,
             Pageable pageable,
             JwtAuthentication auth
     ) {
         return ResponseEntity.ok(
                 teamWeeklyReportService.getTeamMemberWeeklyReports(
+                        request,
                         pageable,
                         auth.getUserId()
                 )

--- a/yaxim/src/main/java/com/yaxim/report/controller/dto/request/TeamMemberWeeklyPageRequest.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/dto/request/TeamMemberWeeklyPageRequest.java
@@ -1,0 +1,15 @@
+package com.yaxim.report.controller.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TeamMemberWeeklyPageRequest {
+    private List<Long> userId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/yaxim/src/main/java/com/yaxim/report/repository/TeamMemberWeeklyPageRepository.java
+++ b/yaxim/src/main/java/com/yaxim/report/repository/TeamMemberWeeklyPageRepository.java
@@ -1,0 +1,94 @@
+package com.yaxim.report.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yaxim.report.controller.dto.request.TeamMemberWeeklyPageRequest;
+import com.yaxim.report.entity.UserWeeklyReport;
+import com.yaxim.team.entity.Team;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.yaxim.report.entity.QUserWeeklyReport.userWeeklyReport;
+
+@Repository
+@Slf4j
+@RequiredArgsConstructor
+public class TeamMemberWeeklyPageRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public Page<UserWeeklyReport> findTeamMemberWeekly(
+            TeamMemberWeeklyPageRequest request,
+            Team team,
+            Pageable pageable
+    ) {
+            List<UserWeeklyReport> content =
+                    queryFactory
+                            .select(userWeeklyReport)
+                            .from(userWeeklyReport)
+                            .where(
+                                    userIdIn(request.getUserId()),
+                                    dateBetween(request.getStartDate(), request.getEndDate()),
+                                    teamEquals(team)
+                            )
+                            .offset(pageable.getOffset())
+                            .limit(pageable.getPageSize())
+                            .orderBy(getSort(pageable, userWeeklyReport))
+                            .fetch();
+
+            JPAQuery<Long> countQuery = queryFactory
+                    .select(userWeeklyReport.count())
+                    .from(userWeeklyReport)
+                    .where(
+                            userIdIn(request.getUserId()),
+                            dateBetween(request.getStartDate(), request.getEndDate())
+                    );
+
+            return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression userIdIn(List<Long> userIds) {
+        return (userIds != null && !userIds.isEmpty()) ?
+                userWeeklyReport.user.id.in(userIds) : null;
+    }
+
+    private BooleanExpression dateBetween(LocalDate startDate, LocalDate endDate) {
+        if (startDate != null && endDate != null) {
+            // 시작 날짜와 종료 날짜가 둘 다 존재할 때
+            return userWeeklyReport.endDate.between(startDate, endDate);
+        } else if (startDate != null) {
+            // 종료 날짜가 없을 때 -> 시작 날짜 이후 모든 데이터
+            return userWeeklyReport.endDate.goe(startDate);
+        } else if (endDate != null) {
+            // 시작 날짜가 없을 때 -> 종료 날짜 이전 모든 데이터
+            return userWeeklyReport.endDate.loe(endDate);
+        } else {
+            // 시작 날짜와 종료 날짜가 모두 없으면 모든 데이터 반환
+            return null;
+        }
+    }
+
+    private BooleanExpression teamEquals(Team team) {
+        return team != null ? userWeeklyReport.team.eq(team) : null;
+    }
+
+    public static <T> OrderSpecifier<?>[] getSort(Pageable pageable, EntityPathBase<T> qClass) {
+        return pageable.getSort().stream().map(order ->
+                        new OrderSpecifier(
+                                Order.valueOf(order.getDirection().name()),
+                                Expressions.path(Object.class, qClass, order.getProperty())
+                        )).toList()
+                .toArray(new OrderSpecifier[0]);
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/report/service/TeamWeeklyReportService.java
+++ b/yaxim/src/main/java/com/yaxim/report/service/TeamWeeklyReportService.java
@@ -1,6 +1,7 @@
 package com.yaxim.report.service;
 
 import com.yaxim.global.for_ai.dto.request.TeamWeeklyReportCreateRequest;
+import com.yaxim.report.controller.dto.request.TeamMemberWeeklyPageRequest;
 import com.yaxim.report.controller.dto.response.TeamMemberWeeklyDetailResponse;
 import com.yaxim.report.controller.dto.response.TeamMemberWeeklyReportResponse;
 import com.yaxim.report.controller.dto.response.WeeklyReportDetailResponse;
@@ -9,6 +10,7 @@ import com.yaxim.report.entity.TeamWeeklyReport;
 import com.yaxim.report.entity.UserWeeklyReport;
 import com.yaxim.report.exception.ReportAccessDeniedException;
 import com.yaxim.report.exception.ReportNotFoundException;
+import com.yaxim.report.repository.TeamMemberWeeklyPageRepository;
 import com.yaxim.report.repository.TeamWeeklyReportRepository;
 import com.yaxim.report.repository.UserWeeklyReportRepository;
 import com.yaxim.team.entity.Team;
@@ -34,6 +36,7 @@ public class TeamWeeklyReportService {
     private final TeamMemberRepository teamMemberRepository;
     private final TeamRepository teamRepository;
     private final UserWeeklyReportRepository userWeeklyReportRepository;
+    private final TeamMemberWeeklyPageRepository teamMemberWeeklyPageRepository;
 
     @Transactional
     public WeeklyReportDetailResponse createTeamWeeklyReport(TeamWeeklyReportCreateRequest request) {
@@ -99,6 +102,7 @@ public class TeamWeeklyReportService {
 
     @Transactional(readOnly = true)
     public Page<TeamMemberWeeklyReportResponse> getTeamMemberWeeklyReports(
+            TeamMemberWeeklyPageRequest request,
             Pageable pageable,
             Long userId
     ) {
@@ -106,12 +110,13 @@ public class TeamWeeklyReportService {
         TeamMember viewer = validateUserAndGetTeamMember(userId);
 
         // 2. 요청자의 팀에 속한 멤버들의 Weekly 조회
-        Page<UserWeeklyReport> report = userWeeklyReportRepository.findByTeam(
-                pageable,
-                viewer.getTeam()
+        Page<UserWeeklyReport> reports = teamMemberWeeklyPageRepository.findTeamMemberWeekly(
+                request,
+                viewer.getTeam(),
+                pageable
         );
 
-        return report.map(TeamMemberWeeklyReportResponse::fromTeam);
+        return reports.map(TeamMemberWeeklyReportResponse::fromTeam);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] TeamMemberWeeklyPageRepository를 만들어 팀원의 Weekly를 유저 아이디 목록, 시작 날짜, 종료 날짜를 입력하여 필터링을 할 수 있는 기능을 추가하였습니다. 자세한 사용법은 하단 스크린샷 부분에 남겨놓겠습니다.
 

## 스크린샷
|필터 사용법|
|--|
|<img width="681" alt="image" src="https://github.com/user-attachments/assets/dc685cda-0c62-41e5-91ff-b6d8c391fb12" />| 

화면처럼 리스트 형식이 아닌, String 형식으로 보내주세용. 띄어쓰기가 있으면 안먹힙니닷
