### PR TITLE
feat: [#90] llm 한 줄 평 저장 기능 및 사용자 회원가입 로직 수정

### DIFF
--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/controller/CommentController.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/controller/CommentController.java
@@ -1,0 +1,38 @@
+package com.yaxim.dashboard.comment.controller;
+
+import com.yaxim.dashboard.comment.controller.dto.response.CommentResponse;
+import com.yaxim.dashboard.comment.service.CommentService;
+import com.yaxim.global.auth.aop.CheckRole;
+import com.yaxim.global.auth.jwt.JwtAuthentication;
+import com.yaxim.user.entity.UserRole;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/comment")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @Operation(description = "유저의 Daily 한 줄 평 조회")
+    @GetMapping("/user")
+    public ResponseEntity<CommentResponse> getUserComment(
+            JwtAuthentication auth
+    ) {
+        return ResponseEntity.ok(commentService.getUserComment(auth.getUserId()));
+    }
+
+    @CheckRole(UserRole.LEADER)
+    @Operation(description = "팀의 Weekly 한 줄 평 조회")
+    @GetMapping("/team")
+    public ResponseEntity<CommentResponse> getTeamComment(
+            JwtAuthentication auth
+    ) {
+        return ResponseEntity.ok(commentService.getTeamComment(auth.getUserId()));
+    }
+
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/controller/dto/response/CommentResponse.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/controller/dto/response/CommentResponse.java
@@ -1,0 +1,20 @@
+package com.yaxim.dashboard.comment.controller.dto.response;
+
+import com.yaxim.dashboard.comment.entity.TeamComment;
+import com.yaxim.dashboard.comment.entity.UserComment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentResponse {
+    private String comment;
+
+    public static CommentResponse from(UserComment comment) {
+        return new CommentResponse(comment.getComment());
+    }
+
+    public static CommentResponse from(TeamComment comment) {
+        return new CommentResponse(comment.getComment());
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/entity/TeamComment.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/entity/TeamComment.java
@@ -1,0 +1,28 @@
+package com.yaxim.dashboard.comment.entity;
+
+import com.yaxim.team.entity.Team;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class TeamComment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Setter
+    private String comment;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Team team;
+
+    public TeamComment(Team team, String comment) {
+        this.team = team;
+        this.comment = comment;
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/entity/UserComment.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/entity/UserComment.java
@@ -1,0 +1,28 @@
+package com.yaxim.dashboard.comment.entity;
+
+import com.yaxim.user.entity.Users;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class UserComment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Setter
+    private String comment;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Users user;
+
+    public UserComment(Users user, String comment) {
+        this.user = user;
+        this.comment = comment;
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/exception/TeamCommentNotFoundException.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/exception/TeamCommentNotFoundException.java
@@ -1,0 +1,10 @@
+package com.yaxim.dashboard.comment.exception;
+
+import com.yaxim.global.error.model.CustomException;
+import com.yaxim.global.error.model.ErrorCode;
+
+public class TeamCommentNotFoundException extends CustomException {
+    public TeamCommentNotFoundException() {
+        super(ErrorCode.TEAM_COMMENT_NOT_FOUND);
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/exception/UserCommentNotFoundException.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/exception/UserCommentNotFoundException.java
@@ -1,0 +1,10 @@
+package com.yaxim.dashboard.comment.exception;
+
+import com.yaxim.global.error.model.CustomException;
+import com.yaxim.global.error.model.ErrorCode;
+
+public class UserCommentNotFoundException extends CustomException {
+    public UserCommentNotFoundException() {
+        super(ErrorCode.USER_COMMENT_NOT_FOUND);
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/repository/TeamCommentRepository.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/repository/TeamCommentRepository.java
@@ -1,0 +1,11 @@
+package com.yaxim.dashboard.comment.repository;
+
+import com.yaxim.dashboard.comment.entity.TeamComment;
+import com.yaxim.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamCommentRepository extends JpaRepository<TeamComment, Long> {
+    Optional<TeamComment> findByTeam(Team team);
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/repository/UserCommentRepository.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/repository/UserCommentRepository.java
@@ -1,0 +1,12 @@
+package com.yaxim.dashboard.comment.repository;
+
+import com.yaxim.dashboard.comment.entity.UserComment;
+import com.yaxim.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserCommentRepository extends JpaRepository<UserComment, Long> {
+    Optional<UserComment> findByUser(Users user);
+    Optional<UserComment> findByUserId(Long userId);
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/comment/service/CommentService.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/comment/service/CommentService.java
@@ -1,0 +1,68 @@
+package com.yaxim.dashboard.comment.service;
+
+import com.yaxim.dashboard.comment.controller.dto.response.CommentResponse;
+import com.yaxim.dashboard.comment.entity.TeamComment;
+import com.yaxim.dashboard.comment.entity.UserComment;
+import com.yaxim.dashboard.comment.exception.TeamCommentNotFoundException;
+import com.yaxim.dashboard.comment.exception.UserCommentNotFoundException;
+import com.yaxim.dashboard.comment.repository.TeamCommentRepository;
+import com.yaxim.dashboard.comment.repository.UserCommentRepository;
+import com.yaxim.team.entity.Team;
+import com.yaxim.team.exception.TeamMemberNotMappedException;
+import com.yaxim.team.repository.TeamMemberRepository;
+import com.yaxim.user.entity.Users;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CommentService {
+    private final UserCommentRepository userCommentRepository;
+    private final TeamCommentRepository teamCommentRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    public CommentResponse getUserComment(Long userId) {
+        UserComment comment = userCommentRepository.findByUserId(userId)
+                .orElseThrow(UserCommentNotFoundException::new);
+
+        return CommentResponse.from(comment);
+    }
+
+    public CommentResponse getTeamComment(Long userId) {
+        Team team = teamMemberRepository.findByUserId(userId)
+                .orElseThrow(TeamMemberNotMappedException::new)
+                .getTeam();
+
+        TeamComment response = teamCommentRepository.findByTeam(team)
+                .orElseThrow(TeamCommentNotFoundException::new);
+
+        return CommentResponse.from(response);
+    }
+
+    public void addComment(Users user, String comment) {
+        UserComment response = userCommentRepository.findByUser(user)
+                .orElse(new UserComment(
+                        user,
+                        ""
+                ));
+
+        response.setComment(comment);
+
+        userCommentRepository.save(response);
+    }
+
+    public void addComment(Team team, String comment) {
+        TeamComment response = teamCommentRepository.findByTeam(team)
+                .orElse(new TeamComment(
+                        team,
+                        ""
+                        )
+                );
+
+        response.setComment(comment);
+
+        teamCommentRepository.save(response);
+    }
+}

--- a/yaxim/src/main/java/com/yaxim/dashboard/statics/service/TeamStaticsService.java
+++ b/yaxim/src/main/java/com/yaxim/dashboard/statics/service/TeamStaticsService.java
@@ -14,7 +14,6 @@ import com.yaxim.team.exception.TeamMemberNotMappedException;
 import com.yaxim.team.repository.TeamMemberRepository;
 import com.yaxim.team.repository.TeamRepository;
 import com.yaxim.user.entity.Users;
-import com.yaxim.user.exception.UserNotFoundException;
 import com.yaxim.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,9 +42,7 @@ public class TeamStaticsService {
         if (hasData) {
             activities = teamStaticsRepository.findAllByTeam(team);
         } else {
-            List<Users> users = userRepository.findAllByEmailIn(
-                    teamMemberRepository.getEmailsByTeamIn(team)
-            );
+            List<Users> users = teamMemberRepository.getUsersByTeamIn(team);
 
             for (int i = 0; i < 7; i++) {
                 TeamActivity data = userStaticsRepository.getTeamActivityByWeekdayAndUser(Weekday.of(i), users);
@@ -111,10 +108,7 @@ public class TeamStaticsService {
     }
 
     private Team getTeamByUserId(Long userId) {
-        Users user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        return teamMemberRepository.findByEmail(user.getEmail())
+        return teamMemberRepository.findByUserId(userId)
                 .orElseThrow(TeamMemberNotMappedException::new)
                 .getTeam();
     }

--- a/yaxim/src/main/java/com/yaxim/git/service/GitInfoService.java
+++ b/yaxim/src/main/java/com/yaxim/git/service/GitInfoService.java
@@ -80,7 +80,7 @@ public class GitInfoService {
 
         Users user = info.getUser();
 
-        TeamMember member = teamMemberRepository.findByEmail(user.getEmail())
+        TeamMember member = teamMemberRepository.findByUserId(user.getId())
                 .orElseThrow(UserNotFoundException::new);
 
         if (!member.getRole().isLeader()) throw new UserHasNoAuthorityException();

--- a/yaxim/src/main/java/com/yaxim/global/auth/aop/TeamRoleAspect.java
+++ b/yaxim/src/main/java/com/yaxim/global/auth/aop/TeamRoleAspect.java
@@ -27,7 +27,7 @@ public class TeamRoleAspect {
     public Object checkRole(ProceedingJoinPoint joinPoint) throws Throwable {
         // 현재 인증 정보 가져오기
         JwtAuthentication authentication = (JwtAuthentication) SecurityContextHolder.getContext().getAuthentication();
-        String email = authentication.getEmail();
+        Long userId = authentication.getUserId();
 
         MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
         Method method = methodSignature.getMethod();
@@ -40,7 +40,7 @@ public class TeamRoleAspect {
             checkRole = joinPoint.getTarget().getClass().getAnnotation(CheckRole.class);
         }
 
-        TeamMember member = teamMemberRepository.findByEmail(email)
+        TeamMember member = teamMemberRepository.findByUserId(userId)
                 .orElseThrow(TeamMemberNotMappedException::new);
 
         if (!member.getRole().equals(checkRole.value())) {

--- a/yaxim/src/main/java/com/yaxim/global/auth/oauth2/CustomOidcUserService.java
+++ b/yaxim/src/main/java/com/yaxim/global/auth/oauth2/CustomOidcUserService.java
@@ -1,5 +1,6 @@
 package com.yaxim.global.auth.oauth2;
 
+import com.yaxim.team.service.TeamService;
 import com.yaxim.user.entity.Users;
 import com.yaxim.user.exception.UserNotFoundException;
 import com.yaxim.user.repository.UserRepository;
@@ -51,7 +52,6 @@ public class CustomOidcUserService extends OidcUserService {
 
             user.setName(oAuth2UserInfo.getName());
         } else {
-            log.info("new user");
             user = userRepository.save(oAuth2UserInfo.toEntity());
         }
     }

--- a/yaxim/src/main/java/com/yaxim/global/auth/oauth2/OAuth2SuccessHandler.java
+++ b/yaxim/src/main/java/com/yaxim/global/auth/oauth2/OAuth2SuccessHandler.java
@@ -9,6 +9,8 @@ import com.yaxim.global.auth.jwt.TokenService;
 import com.yaxim.global.auth.jwt.JwtProvider;
 import com.yaxim.global.auth.jwt.JwtToken;
 import com.yaxim.global.auth.jwt.exception.TokenNotProvidedException;
+import com.yaxim.team.entity.TeamMember;
+import com.yaxim.team.repository.TeamMemberRepository;
 import com.yaxim.team.service.TeamService;
 import com.yaxim.user.entity.Users;
 import com.yaxim.user.exception.UserNotFoundException;
@@ -36,6 +38,7 @@ import java.time.Duration;
 @Component
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
+    private final TeamMemberRepository teamMemberRepository;
     @Value("${redirect.uri.success}")
     private String URI;
     private final TokenService tokenService;
@@ -75,7 +78,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         // OIDC Access Token을 레디스에 저장
         tokenService.storeOidcToken(user.getId().toString(), accessToken, Duration.ofHours(1));
 
-        // Teams 정보와 동기화
+        // Teams 정보와 동기화 (내 정보만 저장)
         teamService.loadTeam(user.getId());
 
         // JWT Token 발급

--- a/yaxim/src/main/java/com/yaxim/global/error/model/ErrorCode.java
+++ b/yaxim/src/main/java/com/yaxim/global/error/model/ErrorCode.java
@@ -53,6 +53,9 @@ public enum ErrorCode {
   
     GIT_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "GIT_INFO_NOT_FOUND" ),
     GIT_EMAIL_IS_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "GIT_EMAIL_IS_NOT_PROVIDED" ),
+
+    USER_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_COMMENT_NOT_FOUND" ),
+    TEAM_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_COMMENT_NOT_FOUND" ),
     ;
 
     private final HttpStatus status;

--- a/yaxim/src/main/java/com/yaxim/project/service/ProjectService.java
+++ b/yaxim/src/main/java/com/yaxim/project/service/ProjectService.java
@@ -12,9 +12,7 @@ import com.yaxim.project.repository.ProjectRepository;
 import com.yaxim.team.entity.Team;
 import com.yaxim.team.exception.TeamMemberNotMappedException;
 import com.yaxim.team.repository.TeamMemberRepository;
-import com.yaxim.user.entity.Users;
 import com.yaxim.user.exception.UserHasNoAuthorityException;
-import com.yaxim.user.exception.UserNotFoundException;
 import com.yaxim.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,10 +49,7 @@ public class ProjectService {
         validateProjectInfo(request);
         validateDateRange(request.getStartDate(), request.getEndDate());
 
-        Users user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        Team team = teamMemberRepository.findByEmail(user.getEmail())
+        Team team = teamMemberRepository.findByUserId(userId)
                 .orElseThrow(TeamMemberNotMappedException::new)
                 .getTeam();
 
@@ -105,10 +100,7 @@ public class ProjectService {
             Pageable pageable,
             Long userId
     ) {
-        Users user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        Team team = teamMemberRepository.findByEmail(user.getEmail())
+        Team team = teamMemberRepository.findByUserId(userId)
                 .orElseThrow(TeamMemberNotMappedException::new)
                 .getTeam();
 
@@ -146,10 +138,7 @@ public class ProjectService {
             validateFileUpload(request.getFiles());
         }
 
-        Users user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        Team team = teamMemberRepository.findByEmail(user.getEmail())
+        Team team = teamMemberRepository.findByUserId(userId)
                 .orElseThrow(TeamMemberNotMappedException::new)
                 .getTeam();
 

--- a/yaxim/src/main/java/com/yaxim/report/controller/TeamWeeklyReportController.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/TeamWeeklyReportController.java
@@ -32,7 +32,7 @@ public class TeamWeeklyReportController {
     @Operation(summary = "팀 멤버 보고서 목록 조회")
     @GetMapping("/member")
     public ResponseEntity<Page<TeamMemberWeeklyReportResponse>> getTeamMemberWeeklyReports(
-            TeamMemberWeeklyPageRequest request,
+            @RequestBody TeamMemberWeeklyPageRequest request,
             Pageable pageable,
             JwtAuthentication auth
     ) {

--- a/yaxim/src/main/java/com/yaxim/report/service/UserWeeklyReportService.java
+++ b/yaxim/src/main/java/com/yaxim/report/service/UserWeeklyReportService.java
@@ -30,7 +30,8 @@ public class UserWeeklyReportService {
     @Transactional
     public WeeklyReportDetailResponse createWeeklyReport(Long userId, WeeklyReportCreateRequest request) {
         Users user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        TeamMember teamMember = teamMemberRepository.findByEmail(user.getEmail()).orElseThrow(TeamMemberNotMappedException::new);
+        TeamMember teamMember = teamMemberRepository.findByUserId(userId)
+                .orElseThrow(TeamMemberNotMappedException::new);
 
         UserWeeklyReport report = UserWeeklyReport.builder()
                 .startDate(request.getStartDate())

--- a/yaxim/src/main/java/com/yaxim/team/controller/TeamController.java
+++ b/yaxim/src/main/java/com/yaxim/team/controller/TeamController.java
@@ -39,7 +39,7 @@ public class TeamController {
     @Operation(summary = "팀 위클리 템플릿 등록/수정")
     @PostMapping("/template")
     public void updateTemplate(
-            WeeklyTemplateRequest request,
+            @RequestBody WeeklyTemplateRequest request,
             JwtAuthentication auth
     ) {
         teamService.updateTemplate(request, auth.getUserId());
@@ -57,14 +57,14 @@ public class TeamController {
         return ResponseEntity.ok(teamService.getUserTeamMembers(auth.getUserId()));
     }
 
-    @Operation(summary = "팀 정보 동기화", description = "Microsoft Teams에 등록되어 있는 팀 정보와 동기화합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "토큰 유효함"),
-            @ApiResponse(responseCode = "401", description = "토큰 유효하지 않음 또는 없음"),
-            @ApiResponse(responseCode = "404", description = "팀 정보를 찾을 수 없음")
-    })
-    @PostMapping("/load")
-    public ResponseEntity<TeamResponse> initTeam(JwtAuthentication auth) {
-        return ResponseEntity.ok(teamService.loadTeam(auth.getUserId()));
-    }
+//    @Operation(summary = "팀 정보 동기화", description = "Microsoft Teams에 등록되어 있는 팀 정보와 동기화합니다.")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "토큰 유효함"),
+//            @ApiResponse(responseCode = "401", description = "토큰 유효하지 않음 또는 없음"),
+//            @ApiResponse(responseCode = "404", description = "팀 정보를 찾을 수 없음")
+//    })
+//    @PostMapping("/load")
+//    public ResponseEntity<TeamResponse> initTeam(JwtAuthentication auth) {
+//        return ResponseEntity.ok(teamService.loadTeam(auth.getUserId()));
+//    }
 }

--- a/yaxim/src/main/java/com/yaxim/team/entity/Team.java
+++ b/yaxim/src/main/java/com/yaxim/team/entity/Team.java
@@ -1,16 +1,10 @@
 package com.yaxim.team.entity;
 
-import com.yaxim.graph.controller.dto.GraphTeamMemberResponse;
 import com.yaxim.global.util.BaseEntity;
-import com.yaxim.team.repository.TeamMemberRepository;
-import com.yaxim.user.entity.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -35,48 +29,5 @@ public class Team extends BaseEntity {
         this.id = id;
         this.name = displayName;
         this.description = description;
-    }
-
-    public void addMember(TeamMember member) {
-        members.add(member);
-        member.setTeam(this);
-    }
-
-    public void removeMember(TeamMember member) {
-        members.remove(member);
-        member.setTeam(null);
-    }
-
-    public void syncMembers(List<GraphTeamMemberResponse.Members> newMembers, TeamMemberRepository teamMemberRepository) {
-        List<TeamMember> currentMembers = teamMemberRepository.findByTeam(this);
-
-        Map<String, TeamMember> currentMap = currentMembers.stream()
-                .collect(Collectors.toMap(TeamMember::getEmail, tm -> tm));
-
-        Set<String> newEmails = newMembers.stream()
-                .map(GraphTeamMemberResponse.Members::getEmail)
-                .collect(Collectors.toSet());
-
-        // 1. 삭제 대상
-        for (TeamMember member : currentMembers) {
-            if (!newEmails.contains(member.getEmail())) {
-                teamMemberRepository.delete(member);
-            }
-        }
-
-        // 2. 추가 및 수정 대상
-        for (GraphTeamMemberResponse.Members m : newMembers) {
-            UserRole newRole = m.roles.isEmpty() ? UserRole.MEMBER : UserRole.LEADER;
-            TeamMember existing = currentMap.get(m.getEmail());
-
-            if (existing == null) {
-                // 추가
-                teamMemberRepository.save(new TeamMember(this, m.getEmail(), newRole));
-            } else if (existing.getRole() != newRole) {
-                // 역할 변경
-                existing.updateRole(newRole);
-                teamMemberRepository.save(existing);
-            }
-        }
     }
 }

--- a/yaxim/src/main/java/com/yaxim/team/entity/TeamMember.java
+++ b/yaxim/src/main/java/com/yaxim/team/entity/TeamMember.java
@@ -1,6 +1,7 @@
 package com.yaxim.team.entity;
 
 import com.yaxim.user.entity.UserRole;
+import com.yaxim.user.entity.Users;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,20 +15,26 @@ public class TeamMember {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
 
-    private String email;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
 
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
-    public TeamMember(Team team, String email, UserRole role) {
+    public TeamMember(Team team, Users user, UserRole role) {
         this.team = team;
-        this.email = email;
+        this.user = user;
         this.role = role;
+    }
+
+    public TeamMember(Team team, Users user) {
+        this.team = team;
+        this.user = user;
     }
 
     public void updateRole(UserRole role) {

--- a/yaxim/src/main/java/com/yaxim/team/repository/TeamMemberRepository.java
+++ b/yaxim/src/main/java/com/yaxim/team/repository/TeamMemberRepository.java
@@ -2,6 +2,7 @@ package com.yaxim.team.repository;
 
 import com.yaxim.team.entity.Team;
 import com.yaxim.team.entity.TeamMember;
+import com.yaxim.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,10 +10,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
-    Optional<TeamMember> findByEmail(String email);
-    List<TeamMember> findByTeam(Team team);
     List<TeamMember> findByTeamId(String teamId);
+    Optional<TeamMember> findByUserId(Long userId);
 
-    @Query("SELECT u.email FROM TeamMember u WHERE u.team = :team")
-    List<String> getEmailsByTeamIn(Team team);
+    @Query("SELECT u.user FROM TeamMember u WHERE u.team = :team")
+    List<Users> getUsersByTeamIn(Team team);
 }

--- a/yaxim/src/main/java/com/yaxim/user/repository/UserRepository.java
+++ b/yaxim/src/main/java/com/yaxim/user/repository/UserRepository.java
@@ -1,14 +1,11 @@
 package com.yaxim.user.repository;
 
-import com.yaxim.user.entity.UserRole;
 import com.yaxim.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByEmail(String email);
     boolean existsByEmail(String email);
-    List<Users> findAllByEmailIn(List<String> emails);
 }

--- a/yaxim/src/main/java/com/yaxim/user/service/UserService.java
+++ b/yaxim/src/main/java/com/yaxim/user/service/UserService.java
@@ -41,7 +41,7 @@ public class UserService {
     }
 
     private UserInfoResponse getUserResponse(Users user) {
-        TeamMember member = teamMemberRepository.findByEmail(user.getEmail())
+        TeamMember member = teamMemberRepository.findByUserId(user.getId())
                 .orElseThrow(UserNotFoundException::new);
 
         GitInfo gitInfo = gitInfoRepository.findByUser(user)

--- a/yaxim/src/main/resources/messages.properties
+++ b/yaxim/src/main/resources/messages.properties
@@ -44,3 +44,6 @@ TEAMS_ANALYTICS_NOT_FOUND=팀 분석 내용을 찾을 수 없습니다.
 
 GIT_INFO_NOT_FOUND=깃 정보가 존재하지 않습니다.
 GIT_EMAIL_IS_NOT_PROVIDED=깃 이메일을 설정해주세요.
+
+USER_COMMENT_NOT_FOUND=사용자의 한 줄 평을 찾을 수 없습니다.
+TEAM_COMMENT_NOT_FOUND=팀의 한 줄 평을 찾을 수 없습니다.

--- a/yaxim/src/main/resources/messages_en_US.properties
+++ b/yaxim/src/main/resources/messages_en_US.properties
@@ -38,3 +38,6 @@ TEAMS_ANALYTICS_NOT_FOUND=Teams Analytics Not Found
 
 GIT_INFO_NOT_FOUND=Git Info Not Found
 GIT_EMAIL_IS_NOT_PROVIDED=Git Email Is Not Provided
+
+USER_COMMENT_NOT_FOUND=User's One Line Comment Not Found
+TEAM_COMMENT_NOT_FOUND=Team's One Line Comment Not Found

--- a/yaxim/src/main/resources/messages_ko_KR.properties
+++ b/yaxim/src/main/resources/messages_ko_KR.properties
@@ -38,3 +38,6 @@ TEAMS_ANALYTICS_NOT_FOUND=팀 분석 내용을 찾을 수 없습니다.
 
 GIT_INFO_NOT_FOUND=깃 정보가 존재하지 않습니다.
 GIT_EMAIL_IS_NOT_PROVIDED=깃 이메일을 설정해주세요.
+
+USER_COMMENT_NOT_FOUND=사용자의 한 줄 평을 찾을 수 없습니다.
+TEAM_COMMENT_NOT_FOUND=팀의 한 줄 평을 찾을 수 없습니다.


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] LLM의 한 줄 평을 저장할 수 있는 엔티티를 따로 추가하였습니다. 데일리 및 위클리가 저장될 때 "daily_short_review" 및 "weekly_short_review"에 있는 내용을 한 줄 평으로 저장합니다.
- [x] 회원가입 및 로그인 로직을 전면(?) 수정하였습니다. 기존 로그인 시 팀원 중 한 명만 로그인을 해도 모든 팀원의 정보를 불러오던 로직에서 로그인을 한 적이 있는 팀원의 정보만 TeamMember 테이블에 저장되도록 수정하였습니다. 이제 TeamMember와 Users 테이블 간 연관관계가 추가됩니다.
 
