### PR TITLE
feat: [#105] AI용 개인 데일리 위클리 불러오기 기능 추가

### DIFF
--- a/yaxim/src/main/java/com/yaxim/global/for_ai/ApiForAiController.java
+++ b/yaxim/src/main/java/com/yaxim/global/for_ai/ApiForAiController.java
@@ -1,8 +1,6 @@
 package com.yaxim.global.for_ai;
 
-import com.yaxim.global.for_ai.dto.request.DailyReportCreateRequest;
-import com.yaxim.global.for_ai.dto.request.TeamWeeklyReportCreateRequest;
-import com.yaxim.global.for_ai.dto.request.WeeklyReportCreateRequest;
+import com.yaxim.global.for_ai.dto.request.*;
 import com.yaxim.global.for_ai.dto.response.TeamWithMemberAndProjectResponse;
 import com.yaxim.report.controller.dto.response.DailyReportDetailResponse;
 import com.yaxim.report.controller.dto.response.WeeklyReportDetailResponse;
@@ -64,5 +62,23 @@ public class ApiForAiController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    // TODO LLM One Line Comment (DailyUserReport 테이블에 Comment 컬럼 추가)
+    @Operation(summary = "User ID로 개인 데일리 불러오기")
+    @PostMapping("/user-daily")
+    public ResponseEntity<List<DailyReportDetailResponse>> getMyDailyReport(
+            @RequestBody UserDailyListRequest request
+            ) {
+        return ResponseEntity.ok(
+                userDailyReportService.getUserDailyReport(request)
+        );
+    }
+
+    @Operation(summary = "Team ID로 개인 위클리 불러오기")
+    @PostMapping("/user-weekly")
+    public ResponseEntity<List<WeeklyReportDetailResponse>> getMyWeeklyReport(
+            @RequestBody UserWeeklyListRequest request
+            ) {
+        return ResponseEntity.ok(
+                userDailyReportService.getUserWeeklyReport(request)
+        );
+    }
 }

--- a/yaxim/src/main/java/com/yaxim/global/for_ai/dto/request/UserDailyListRequest.java
+++ b/yaxim/src/main/java/com/yaxim/global/for_ai/dto/request/UserDailyListRequest.java
@@ -1,0 +1,14 @@
+package com.yaxim.global.for_ai.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UserDailyListRequest {
+    private Long userId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/yaxim/src/main/java/com/yaxim/global/for_ai/dto/request/UserWeeklyListRequest.java
+++ b/yaxim/src/main/java/com/yaxim/global/for_ai/dto/request/UserWeeklyListRequest.java
@@ -1,0 +1,14 @@
+package com.yaxim.global.for_ai.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UserWeeklyListRequest {
+    private String teamId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/yaxim/src/main/java/com/yaxim/report/controller/TeamWeeklyReportController.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/TeamWeeklyReportController.java
@@ -30,7 +30,7 @@ public class TeamWeeklyReportController {
     private final TeamWeeklyReportService teamWeeklyReportService; // 주입 필요
 
     @Operation(summary = "팀 멤버 보고서 목록 조회")
-    @GetMapping("/member")
+    @PostMapping("/member")
     public ResponseEntity<Page<TeamMemberWeeklyReportResponse>> getTeamMemberWeeklyReports(
             @RequestBody TeamMemberWeeklyPageRequest request,
             Pageable pageable,

--- a/yaxim/src/main/java/com/yaxim/report/repository/UserDailyReportRepository.java
+++ b/yaxim/src/main/java/com/yaxim/report/repository/UserDailyReportRepository.java
@@ -8,11 +8,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface UserDailyReportRepository extends JpaRepository<UserDailyReport, Long> {
 
     @Query(value = "SELECT r FROM UserDailyReport r JOIN FETCH r.user JOIN FETCH r.team WHERE r.user.id = :userId",
             countQuery = "SELECT count(r) FROM UserDailyReport r WHERE r.user.id = :userId")
     Page<UserDailyReport> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    List<UserDailyReport> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 }
 

--- a/yaxim/src/main/java/com/yaxim/report/repository/UserWeeklyReportRepository.java
+++ b/yaxim/src/main/java/com/yaxim/report/repository/UserWeeklyReportRepository.java
@@ -9,6 +9,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface UserWeeklyReportRepository extends JpaRepository<UserWeeklyReport, Long> {
 
@@ -16,6 +19,9 @@ public interface UserWeeklyReportRepository extends JpaRepository<UserWeeklyRepo
             countQuery = "SELECT count(r) FROM UserWeeklyReport r WHERE r.user.id = :userId")
     Page<UserWeeklyReport> findByUserId(@Param("userId") Long userId, Pageable pageable);
 
-    Page<UserWeeklyReport> findByTeam(Pageable pageable, Team team);
+    List<UserWeeklyReport> findByTeam(Team team);
+    List<UserWeeklyReport> findByTeamIdAndStartDateAndEndDate(
+            String teamId, LocalDate startDate, LocalDate endDate
+    );
 }
 

--- a/yaxim/src/main/java/com/yaxim/report/service/UserDailyReportService.java
+++ b/yaxim/src/main/java/com/yaxim/report/service/UserDailyReportService.java
@@ -2,23 +2,32 @@ package com.yaxim.report.service;
 
 import com.yaxim.dashboard.comment.service.CommentService;
 import com.yaxim.global.for_ai.dto.request.DailyReportCreateRequest;
+import com.yaxim.global.for_ai.dto.request.UserDailyListRequest;
+import com.yaxim.global.for_ai.dto.request.UserWeeklyListRequest;
 import com.yaxim.report.controller.dto.response.DailyReportDetailResponse;
 import com.yaxim.report.controller.dto.response.DailyReportResponse;
+import com.yaxim.report.controller.dto.response.WeeklyReportDetailResponse;
 import com.yaxim.report.entity.UserDailyReport;
+import com.yaxim.report.entity.UserWeeklyReport;
 import com.yaxim.report.exception.ReportAccessDeniedException;
 import com.yaxim.report.exception.ReportNotFoundException;
 import com.yaxim.report.repository.UserDailyReportRepository;
+import com.yaxim.report.repository.UserWeeklyReportRepository;
 import com.yaxim.team.entity.TeamMember;
 import com.yaxim.team.exception.TeamMemberNotMappedException;
 import com.yaxim.team.repository.TeamMemberRepository;
+import com.yaxim.team.repository.TeamRepository;
 import com.yaxim.user.entity.Users;
 import com.yaxim.user.exception.UserNotFoundException;
 import com.yaxim.user.repository.UserRepository;
+import org.springdoc.core.service.RequestBodyService;
 import org.springframework.transaction.annotation.Transactional; // Spring의 Transactional import
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +37,9 @@ public class UserDailyReportService {
     private final UserRepository userRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final CommentService commentService;
+    private final UserWeeklyReportRepository userWeeklyReportRepository;
+    private final TeamRepository teamRepository;
+    private final RequestBodyService requestBodyBuilder;
 
     @Transactional
     public DailyReportDetailResponse createDailyReport(Long userId, DailyReportCreateRequest request) {
@@ -75,5 +87,34 @@ public class UserDailyReportService {
             throw new ReportAccessDeniedException();
         }
         dailyReportRepository.delete(report);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DailyReportDetailResponse> getUserDailyReport(
+            UserDailyListRequest request
+    ) {
+        List<UserDailyReport> reports = dailyReportRepository.findByUserIdAndDateBetween(
+                request.getUserId(),
+                request.getStartDate(),
+                request.getEndDate()
+        );
+        return reports.stream()
+                .map(DailyReportDetailResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<WeeklyReportDetailResponse> getUserWeeklyReport(
+            UserWeeklyListRequest request
+    ) {
+        List<UserWeeklyReport> reports = userWeeklyReportRepository.findByTeamIdAndStartDateAndEndDate(
+                request.getTeamId(),
+                request.getStartDate(),
+                request.getEndDate()
+        );
+
+        return reports.stream()
+                .map(WeeklyReportDetailResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] AI에서 사용자 아이디와 startDate, endDate를 기준으로 개인 데일리 목록을 조회할 수 있고, 팀 아이디와 startDate, endDate를 기준으로 개인 위클리 목록을 조회할 수 있습니다.