### PR TITLE
feat: [#110] 팀 Weekly 생성 시 프로젝트 진척도 저장 기능 추가

### DIFF
--- a/yaxim/src/main/java/com/yaxim/global/for_ai/ApiForAiController.java
+++ b/yaxim/src/main/java/com/yaxim/global/for_ai/ApiForAiController.java
@@ -3,6 +3,7 @@ package com.yaxim.global.for_ai;
 import com.yaxim.global.for_ai.dto.request.*;
 import com.yaxim.global.for_ai.dto.response.TeamWithMemberAndProjectResponse;
 import com.yaxim.report.controller.dto.response.DailyReportDetailResponse;
+import com.yaxim.report.controller.dto.response.TeamWeeklyReportResponse;
 import com.yaxim.report.controller.dto.response.WeeklyReportDetailResponse;
 import com.yaxim.report.service.TeamWeeklyReportService;
 import com.yaxim.report.service.UserDailyReportService;
@@ -56,9 +57,9 @@ public class ApiForAiController {
 
     @Operation(summary = "팀 Weekly 생성")
     @PostMapping("/report/team-weekly")
-    public ResponseEntity<WeeklyReportDetailResponse> createTeamWeeklyReport(
+    public ResponseEntity<TeamWeeklyReportResponse> createTeamWeeklyReport(
             @Valid @RequestBody TeamWeeklyReportCreateRequest request) {
-        WeeklyReportDetailResponse response = teamWeeklyReportService.createTeamWeeklyReport(request);
+        TeamWeeklyReportResponse response = teamWeeklyReportService.createTeamWeeklyReport(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/yaxim/src/main/java/com/yaxim/project/controller/dto/response/ProjectDetailResponse.java
+++ b/yaxim/src/main/java/com/yaxim/project/controller/dto/response/ProjectDetailResponse.java
@@ -29,6 +29,9 @@ public class ProjectDetailResponse {
     @Schema(description = "프로젝트명", example = "웹 애플리케이션 개발")
     private String name;
 
+    @Schema(description = "프로젝트 진척도", example = "65")
+    private Integer progress;
+
     @Schema(description = "프로젝트 시작일", example = "2024-01-01")
     private LocalDate startDate;
 
@@ -50,6 +53,7 @@ public class ProjectDetailResponse {
                 .createdAt(project.getCreatedAt())
                 .updatedAt(project.getUpdatedAt())
                 .name(project.getName())
+                .progress(project.getProgress())
                 .startDate(project.getStartDate())
                 .endDate(project.getEndDate())
                 .description(project.getDescription())

--- a/yaxim/src/main/java/com/yaxim/project/entity/Project.java
+++ b/yaxim/src/main/java/com/yaxim/project/entity/Project.java
@@ -28,6 +28,9 @@ public class Project extends BaseEntity {
     @Column(nullable = false, length = 200)
     private String name;
 
+    @Setter
+    private Integer progress;
+
     @NotNull
     @JoinColumn(name = "team_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)

--- a/yaxim/src/main/java/com/yaxim/project/service/ProjectService.java
+++ b/yaxim/src/main/java/com/yaxim/project/service/ProjectService.java
@@ -24,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -122,6 +123,17 @@ public class ProjectService {
                         p.getEndDate(),
                         p.calculateStatus()
                 ));
+    }
+
+    @Transactional
+    public void updateProjectProgress(List<Map<String, Object>> report) {
+        report.forEach(r -> {
+            Map<String, Object> teamProgress = (Map<String, Object>) r.get("team_progress_overview");
+
+            Project project = findProjectById(Long.parseLong(r.get("project_id").toString()));
+
+            project.setProgress(Integer.parseInt(teamProgress.get("overall_progress").toString()));
+        });
     }
 
     /**

--- a/yaxim/src/main/java/com/yaxim/report/controller/TeamWeeklyReportController.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/TeamWeeklyReportController.java
@@ -3,10 +3,7 @@ package com.yaxim.report.controller;
 import com.yaxim.global.auth.aop.CheckRole;
 import com.yaxim.global.auth.jwt.JwtAuthentication;
 import com.yaxim.report.controller.dto.request.TeamMemberWeeklyPageRequest;
-import com.yaxim.report.controller.dto.response.TeamMemberWeeklyDetailResponse;
-import com.yaxim.report.controller.dto.response.TeamMemberWeeklyReportResponse;
-import com.yaxim.report.controller.dto.response.WeeklyReportDetailResponse;
-import com.yaxim.report.controller.dto.response.WeeklyReportResponse;
+import com.yaxim.report.controller.dto.response.*;
 import com.yaxim.report.service.TeamWeeklyReportService;
 import com.yaxim.user.entity.UserRole;
 import io.swagger.v3.oas.annotations.Operation;
@@ -61,21 +58,21 @@ public class TeamWeeklyReportController {
 
     @Operation(summary = "팀 위클리 보고서 목록 조회")
     @GetMapping
-    public ResponseEntity<Page<WeeklyReportResponse>> getTeamWeeklyReports(
+    public ResponseEntity<Page<TeamWeeklyReportResponse>> getTeamWeeklyReports(
             @Parameter(hidden = true) JwtAuthentication auth,
             @PageableDefault(sort = "startDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<WeeklyReportResponse> reports = teamWeeklyReportService.getTeamWeeklyReport(auth.getUserId(), pageable);
+        Page<TeamWeeklyReportResponse> reports = teamWeeklyReportService.getTeamWeeklyReport(auth.getUserId(), pageable);
         return ResponseEntity.ok(reports);
     }
 
     @Operation(summary = "팀 위클리 보고서 상세 조회")
     @GetMapping("/{reportId}")
-    public ResponseEntity<WeeklyReportDetailResponse> getTeamWeeklyReport(
+    public ResponseEntity<TeamWeeklyDetailResponse> getTeamWeeklyReport(
             @PathVariable Long reportId,
             @Parameter(hidden = true) JwtAuthentication auth
     ) {
-        WeeklyReportDetailResponse report = teamWeeklyReportService.getReportById(reportId, auth.getUserId());
+        TeamWeeklyDetailResponse report = teamWeeklyReportService.getReportById(reportId, auth.getUserId());
         return ResponseEntity.ok(report);
     }
 

--- a/yaxim/src/main/java/com/yaxim/report/controller/dto/response/TeamWeeklyDetailResponse.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/dto/response/TeamWeeklyDetailResponse.java
@@ -1,7 +1,6 @@
 package com.yaxim.report.controller.dto.response;
 
-import com.yaxim.report.entity.UserWeeklyReport;
-import com.yaxim.user.entity.Users;
+import com.yaxim.report.entity.TeamWeeklyReport;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +11,7 @@ import java.util.Map;
 
 @Getter
 @AllArgsConstructor
-public class TeamMemberWeeklyDetailResponse {
+public class TeamWeeklyDetailResponse {
     @Schema(description = "보고서 ID")
     private Long id;
 
@@ -31,29 +30,24 @@ public class TeamMemberWeeklyDetailResponse {
     @Schema(description = "보고서 제목")
     private String title;
 
+    @Schema(description = "보고서 내용 (md 형식)")
+    private String reportMd;
+
     @Schema(description = "보고서 내용 (JSON 객체)")
-    private Object report;
+    private Object reportJson;
 
-    @Schema(description = "작성자 ID (개인 보고서만 해당)")
-    private Long userId;
-
-    @Schema(description = "작성자 이름 (개인 보고서만 해당)")
-    private String userName;
-
-    public static TeamMemberWeeklyDetailResponse from(UserWeeklyReport report) {
+    public static TeamWeeklyDetailResponse from(TeamWeeklyReport report) {
         Map<String, Object> reportMap = report.getReport();
-        Users user = report.getUser();
 
-        return new TeamMemberWeeklyDetailResponse(
+        return new TeamWeeklyDetailResponse(
                 report.getId(),
                 report.getCreatedAt(),
                 report.getUpdatedAt(),
                 report.getStartDate(),
                 report.getEndDate(),
                 (String) reportMap.getOrDefault("report_title", ""),
-                reportMap,
-                user.getId(),
-                user.getName()
+                (String) reportMap.getOrDefault("weekly_report_md", ""),
+                reportMap
         );
     }
 }

--- a/yaxim/src/main/java/com/yaxim/report/controller/dto/response/TeamWeeklyReportResponse.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/dto/response/TeamWeeklyReportResponse.java
@@ -1,7 +1,6 @@
 package com.yaxim.report.controller.dto.response;
 
-import com.yaxim.report.entity.UserWeeklyReport;
-import com.yaxim.user.entity.Users;
+import com.yaxim.report.entity.TeamWeeklyReport;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +11,7 @@ import java.util.Map;
 
 @Getter
 @AllArgsConstructor
-public class TeamMemberWeeklyDetailResponse {
+public class TeamWeeklyReportResponse {
     @Schema(description = "보고서 ID")
     private Long id;
 
@@ -31,29 +30,18 @@ public class TeamMemberWeeklyDetailResponse {
     @Schema(description = "보고서 제목")
     private String title;
 
-    @Schema(description = "보고서 내용 (JSON 객체)")
-    private Object report;
-
-    @Schema(description = "작성자 ID (개인 보고서만 해당)")
-    private Long userId;
-
-    @Schema(description = "작성자 이름 (개인 보고서만 해당)")
-    private String userName;
-
-    public static TeamMemberWeeklyDetailResponse from(UserWeeklyReport report) {
+    public static TeamWeeklyReportResponse from(TeamWeeklyReport report) {
         Map<String, Object> reportMap = report.getReport();
-        Users user = report.getUser();
 
-        return new TeamMemberWeeklyDetailResponse(
+        String reportTitle = (String) reportMap.getOrDefault("report_title", "");
+
+        return new TeamWeeklyReportResponse(
                 report.getId(),
                 report.getCreatedAt(),
                 report.getUpdatedAt(),
                 report.getStartDate(),
                 report.getEndDate(),
-                (String) reportMap.getOrDefault("report_title", ""),
-                reportMap,
-                user.getId(),
-                user.getName()
+                reportTitle
         );
     }
 }

--- a/yaxim/src/main/java/com/yaxim/report/controller/dto/response/WeeklyReportDetailResponse.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/dto/response/WeeklyReportDetailResponse.java
@@ -34,20 +34,6 @@ public class WeeklyReportDetailResponse {
     @Schema(description = "보고서 내용 (JSON 객체)")
     private Object report;
 
-    public static WeeklyReportDetailResponse from(TeamWeeklyReport report) {
-        Map<String, Object> reportMap = report.getReport();
-
-        return new WeeklyReportDetailResponse(
-                report.getId(),
-                report.getCreatedAt(),
-                report.getUpdatedAt(),
-                report.getStartDate(),
-                report.getEndDate(),
-                (String) reportMap.getOrDefault("title", ""),
-                reportMap
-        );
-    }
-
     public static WeeklyReportDetailResponse from(UserWeeklyReport report) {
         Map<String, Object> reportMap = report.getReport();
 
@@ -57,7 +43,7 @@ public class WeeklyReportDetailResponse {
                 report.getUpdatedAt(),
                 report.getStartDate(),
                 report.getEndDate(),
-                (String) reportMap.getOrDefault("title", ""),
+                (String) reportMap.getOrDefault("report_title", ""),
                 reportMap
         );
     }

--- a/yaxim/src/main/java/com/yaxim/report/controller/dto/response/WeeklyReportResponse.java
+++ b/yaxim/src/main/java/com/yaxim/report/controller/dto/response/WeeklyReportResponse.java
@@ -1,6 +1,5 @@
 package com.yaxim.report.controller.dto.response;
 
-import com.yaxim.report.entity.TeamWeeklyReport;
 import com.yaxim.report.entity.UserWeeklyReport;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -34,26 +33,7 @@ public class WeeklyReportResponse {
     @Schema(description = "보고서 미리보기")
     private String preview;
 
-    public static WeeklyReportResponse fromTeam(TeamWeeklyReport report) {
-        Map<String, Object> reportMap = report.getReport();
-
-        String reportTitle = (String) reportMap.getOrDefault("report_title", "");
-        // 중첩된 Map 꺼내기
-        Map<String, Object> weeklyReportMap = (Map<String, Object>) reportMap.get("team_weekly_report");
-        String summary = (String) weeklyReportMap.getOrDefault("summary", "");
-
-        return new WeeklyReportResponse(
-                report.getId(),
-                report.getCreatedAt(),
-                report.getUpdatedAt(),
-                report.getStartDate(),
-                report.getEndDate(),
-                reportTitle,
-                summary
-        );
-    }
-
-    public static WeeklyReportResponse fromTeam(UserWeeklyReport report) {
+    public static WeeklyReportResponse from(UserWeeklyReport report) {
         Map<String, Object> reportMap = report.getReport();
 
         String reportTitle = (String) reportMap.getOrDefault("report_title", "");

--- a/yaxim/src/main/java/com/yaxim/report/service/UserWeeklyReportService.java
+++ b/yaxim/src/main/java/com/yaxim/report/service/UserWeeklyReportService.java
@@ -48,7 +48,7 @@ public class UserWeeklyReportService {
     @Transactional(readOnly = true)
     public Page<WeeklyReportResponse> getMyWeeklyReports(Long userId, Pageable pageable) {
         return weeklyReportRepository.findByUserId(userId, pageable)
-                .map(WeeklyReportResponse::fromTeam);
+                .map(WeeklyReportResponse::from);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] 팀 Weekly 템플릿의 변경으로 인해, 팀과 개인의 Weekly Response를 분리하였습니다. 이제 팀 Weekly는 Summary가 없습니다.
- [x] 프로젝트 진척도 저장용 컬럼을 추가하여 팀 Weekly 생성 시, 프로젝트의 진척도가 갱신되어 저장되는 기능을 구현하였습니다.
