### PR TITLE
fix: Git 연동을 위한 OAuth 로그인 시, name이 없으면 로그인 되지 않는 오류 수정

### DIFF
--- a/yaxim/src/main/java/com/yaxim/global/auth/oauth2/OAuth2UserInfo.java
+++ b/yaxim/src/main/java/com/yaxim/global/auth/oauth2/OAuth2UserInfo.java
@@ -54,8 +54,13 @@ public class OAuth2UserInfo {
         String gitUrl = (String) attributes.get("html_url");
         String avatarUrl = (String) attributes.get("avatar_url");
 
+        if (name == null) {
+            name = login;
+        }
+
         if (email == null) {
-            throw new GitEmailIsNotProvidedException();
+//            throw new GitEmailIsNotProvidedException();
+            email = login + "@users.noreply.github.com";
         }
 
         return OAuth2UserInfo.builder()


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [x] Git 로그인 시, 사용자가 이름을 정해주지 않으면 null 로 전달이 되는데 이때 OAuth 에서 사용하는 PrincipalUser 클래스에서 반환하는 name의 값이 null 로 반환되어 오류가 발생하였습니다. 이를 수정하여 현재는 정상적으로 로그인할 수 있습니다!
